### PR TITLE
Updated rules

### DIFF
--- a/content/rules.md
+++ b/content/rules.md
@@ -16,16 +16,12 @@ Jacek added
 
 Alle løb registreres via Strava. Kun registrerede løb tæller og fejl 40 er for egen regning - no mercy.
 
-Alle deltagere vælger frit 3 stjernepunkter inden for hovedstadsområdet. (15 km radius fra Candy Kiosk, Falkoner alle 59)
+Hvert løbet kilometer giver 1 point. Som startbonus gives 3 point for at komme ud at løbe, dog kun én startbonus per dag og betinget af at man uploader billede eller film fra turen til Facebook-gruppen. Der fintælles ved konkurrencens afslutning.
 
-Hvert løbet kilometer giver 1 point. Som startbonus gives 2 point for at komme ud at løbe, dog kun én startbonus per dag og betinget af at man uploader billede eller film fra turen til Facebook-gruppen. Der fintælles ved konkurrencens afslutning.
-
-Hvert løb skal være mindst 3 km og skal forgå i løb udendørs. 
+Hvert løb skal være mindst 3 km og skal forgå udendørs i løbetempo. 
 
 Hvert stjernepunkt passeret giver 2 point. Et stjernepunkt tæller kun første gang det passeres i løbet af konkurrencen. Hvis alle stjernepunkter passeres, så udløses en bonus på 50 point.
 
-Der vil være to ugekonkurrencer, hvor der gives 30 point til henholdsvis flest km (3. Uge) og flest stjerner(5. Uge). Kun stjerner, der ikke tidligere er passeret tæller i 5. uge. 
-
-Positionskampen. Efter hvert løb gives der ét point pr konkurrencedeltager, som passeres på leaderboardet (opgjort før disse point tildeles). 
+Der vil være to ugekonkurrencer, hvor der gives 30 point til henholdsvis flest nye stjerner (Uge 20) og flest kilometer (Uge 22). Kun stjerner, der ikke tidligere er passeret tæller i Uge 20. 
 
 Løb, stjernepunkter og billeder skal uploades samme dato som løbeturen er løbet.


### PR DESCRIPTION
# Rules of the competition

Alle løb registreres via Strava. Kun registrerede løb tæller og fejl 40 er for egen regning - no mercy.

Hvert løbet kilometer giver 1 point. Som startbonus gives 3 point for at komme ud at løbe, dog kun én startbonus per dag og betinget af at man uploader billede eller film fra turen til Facebook-gruppen. Der fintælles ved konkurrencens afslutning.

Hvert løb skal være mindst 3 km og skal forgå udendørs i løbetempo. 

Hvert stjernepunkt passeret giver 2 point. Et stjernepunkt tæller kun første gang det passeres i løbet af konkurrencen. Hvis alle stjernepunkter passeres, så udløses en bonus på 50 point.

Der vil være to ugekonkurrencer, hvor der gives 30 point til henholdsvis flest nye stjerner (Uge 20) og flest kilometer (Uge 22). Kun stjerner, der ikke tidligere er passeret tæller i Uge 20. 

Løb, stjernepunkter og billeder skal uploades samme dato som løbeturen er løbet.